### PR TITLE
Fixed the Download Builder markup that caused cssclasses checkbox to be hidden on page load

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -79,8 +79,8 @@ body_id: builder
                         <li id="load"><label><input type="checkbox" checked value="load" /> Modernizr.load <br>( <a href="http://yepnopejs.com/" target="_new">yepnope.js</a> )</label></li>
                         <li id="mq"><label><input type="checkbox" value="mq" /> Media Queries</label></li>
                         <li id="cssclasses">
+                          <label><input type="checkbox" checked value="cssclasses" /> Add CSS Classes</label>
                           <div id="cssprefixcontainer">
-                            <label><input type="checkbox" checked value="cssclasses" /> Add CSS Classes</label>
                             <label><abbr class="help" title="Add a prefix if Modernizr’s default class names conflict with your CSS. A prefix of `mod-` means classes like `.mod-video`">className prefix:</abbr><input type="text" id="cssprefix" class="textfield" /></label>
                           </div>
                         </li>


### PR DESCRIPTION
Corresponding issue: https://github.com/Modernizr/Modernizr/issues/547
