### PR TITLE
Fix the build URL for some non-core detects

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -112,7 +112,7 @@ body_id: builder
                           <li id="audio_webaudio_api"><label><input type="checkbox" value="audio_webaudio_api"> audio-webaudio-api</label></li>
                           <li id="battery_api"><label><input type="checkbox" value="battery_api"> battery-api</label></li>
                           <li id="battery_level"><label><input type="checkbox" value="battery_level"> battery-level</label></li>
-                          <li id="blob-constructor"><label><input type="checkbox" value="blob-constructor"> blob-constructor</label></li>
+                          <li id="blob_constructor"><label><input type="checkbox" value="blob_constructor"> blob-constructor</label></li>
                           <li id="canvas_todataurl_type"><label><input type="checkbox" value="canvas_todataurl_type"> canvas-todataurl-type</label></li>
                           <li id="contenteditable"><label><input type="checkbox" value="contenteditable"> contenteditable</label></li>
 
@@ -128,8 +128,8 @@ body_id: builder
                           <li id="css_backgroundcliptext"><label><input type="checkbox" value="css_backgroundcliptext"> css-backgroundcliptext</label></li>
                         -->
 
-                          <li id="css-backgroundposition-shorthand"><label><input type="checkbox" value="css-backgroundposition-shorthand"> css-backgroundposition-shorthand</label></li>
-                          <li id="css-backgroundposition-xy"><label><input type="checkbox" value="css-backgroundposition-xy"> css-backgroundposition-xy</label></li>
+                          <li id="css_backgroundposition_shorthand"><label><input type="checkbox" value="css_backgroundposition_shorthand"> css-backgroundposition-shorthand</label></li>
+                          <li id="css_backgroundposition_xy"><label><input type="checkbox" value="css_backgroundposition_xy"> css-backgroundposition-xy</label></li>
                           <li id="css_backgroundrepeat"><label><input type="checkbox" value="css_backgroundrepeat"> css-backgroundrepeat</label></li>
                           <li id="css_backgroundsizecover"><label><input type="checkbox" value="css_backgroundsizecover"> css-backgroundsizecover</label></li>
                           <li id="css_boxsizing"><label><input type="checkbox" value="css_boxsizing"> css-boxsizing</label></li>
@@ -139,32 +139,32 @@ body_id: builder
                           <li id="css_displaytable"><label><input type="checkbox" value="css_displaytable"> css-displaytable</label></li>
                           <li id="css_filters"><label><input type="checkbox" value="css_filters"> css-filters</label></li>
                           <li id="css_hyphens"><label><input type="checkbox" value="css_hyphens"> css-hyphens</label></li>
-                          <li id="css-lastchild"><label><input type="checkbox" value="css-lastchild"> css-lastchild</label></li>
+                          <li id="css_lastchild"><label><input type="checkbox" value="css_lastchild"> css-lastchild</label></li>
                           <li id="css_mask"><label><input type="checkbox" value="css_mask"> css-mask</label></li>
                           <li id="css_mediaqueries"><label><input type="checkbox" value="css_mediaqueries"> css-mediaqueries</label></li>
-                          <li id="css-objectfit"><label><input type="checkbox" value="css-objectfit"> css-objectfit</label></li>
+                          <li id="css_objectfit"><label><input type="checkbox" value="css_objectfit"> css-objectfit</label></li>
 
 
 
                           <li id="css_overflow_scrolling"><label><input type="checkbox" value="css_overflow_scrolling"> css-overflow-scrolling</label></li>
                           <li id="css_pointerevents"><label><input type="checkbox" value="css_pointerevents"> css-pointerevents</label></li>
-                          <li id="css-positionsticky"><label><input type="checkbox" value="css-positionsticky"> css-positionsticky</label></li>
+                          <li id="css_positionsticky"><label><input type="checkbox" value="css_positionsticky"> css-positionsticky</label></li>
 
 
 
                           <li id="css_remunit"><label><input type="checkbox" value="css_remunit"> css-remunit</label></li>
-                          <li id="css-regions"><label><input type="checkbox" value="css-regions"> css-regions</label></li>
+                          <li id="css_regions"><label><input type="checkbox" value="css_regions"> css-regions</label></li>
                           <li id="css_resize"><label><input type="checkbox" value="css_resize"> css-resize</label></li>
                           <li id="css_scrollbars"><label><input type="checkbox" value="css_scrollbars"> css-scrollbars</label></li>
-                          <li id="css-subpixelfont"><label><input type="checkbox" value="css-subpixelfont"> css-subpixelfont</label></li>
-                          <li id="css-supports"><label><input type="checkbox" value="css-supports"> css @supports</label></li>
+                          <li id="css_subpixelfont"><label><input type="checkbox" value="css_subpixelfont"> css-subpixelfont</label></li>
+                          <li id="css_supports"><label><input type="checkbox" value="css_supports"> css @supports</label></li>
 
                           <li id="css_userselect"><label><input type="checkbox" value="css_userselect"> css-userselect</label></li>
 
-                          <li id="css-vhunit"><label><input type="checkbox" value="css-vhunit"> css-vhunit</label></li>
-                          <li id="css-vmaxunit"><label><input type="checkbox" value="css-vmaxunit"> css-vmaxunit</label></li>
-                          <li id="css-vminunit"><label><input type="checkbox" value="css-vminunit"> css-vminunit</label></li>
-                          <li id="css-vwunit"><label><input type="checkbox" value="css-vwunit"> css-vwunit</label></li>
+                          <li id="css_vhunit"><label><input type="checkbox" value="css_vhunit"> css-vhunit</label></li>
+                          <li id="css_vmaxunit"><label><input type="checkbox" value="css_vmaxunit"> css-vmaxunit</label></li>
+                          <li id="css_vminunit"><label><input type="checkbox" value="css_vminunit"> css-vminunit</label></li>
+                          <li id="css_vwunit"><label><input type="checkbox" value="css_vwunit"> css-vwunit</label></li>
 
 
                           <li id="custom_protocol_handler"><label><input type="checkbox" value="custom_protocol_handler"> custom-protocol-handler</label></li>
@@ -186,7 +186,7 @@ body_id: builder
                           <li id="exif_orientation"><label><input type="checkbox" value="exif_orientation"> exif-orientation</label></li>
                           <li id="file_api"><label><input type="checkbox" value="file_api"> file-api</label></li>
                           <li id="forms_fileinput"><label><input type="checkbox" value="forms_fileinput"> forms-fileinput</label></li>
-                          <li id="forms-formattribute"><label><input type="checkbox" value="forms-formattribute"> forms-formattribute</label></li>
+                          <li id="forms_formattribute"><label><input type="checkbox" value="forms_formattribute"> forms-formattribute</label></li>
 
 
                           <li id="file_filesystem"><label><input type="checkbox" value="file_filesystem"> file-filesystem</label></li>
@@ -197,9 +197,9 @@ body_id: builder
                           <li id="gamepad"><label><input type="checkbox" value="gamepad"> gamepad</label></li>
                           <li id="getusermedia"><label><input type="checkbox" value="getusermedia"> getusermedia</label></li>
                           <li id="ie8compat"><label><input type="checkbox" value="ie8compat"> ie8compat</label></li>
-                          <li id="iframe-sandbox"><label><input type="checkbox" value="iframe-sandbox"> iframe-sandbox</label></li>
-                          <li id="iframe-seamless"><label><input type="checkbox" value="iframe-seamless"> iframe-seamless</label></li>
-                          <li id="iframe-srcdoc"><label><input type="checkbox" value="iframe-srcdoc"> iframe-srcdoc</label></li>
+                          <li id="iframe_sandbox"><label><input type="checkbox" value="iframe_sandbox"> iframe-sandbox</label></li>
+                          <li id="iframe_seamless"><label><input type="checkbox" value="iframe_seamless"> iframe-seamless</label></li>
+                          <li id="iframe_srcdoc"><label><input type="checkbox" value="iframe_srcdoc"> iframe-srcdoc</label></li>
 
 
                           <li id="img_apng"><label><input type="checkbox" value="img_apng"> img-apng</label></li>
@@ -209,17 +209,17 @@ body_id: builder
                           <li id="mathml"><label><input type="checkbox" value="mathml"> mathml</label></li>
                           <li id="network_connection"><label><input type="checkbox" value="network_connection"> network-connection</label></li>
                           <li id="network_eventsource"><label><input type="checkbox" value="network_eventsource"> network-eventsource</label></li>
-                          <li id="network-xhr2"><label><input type="checkbox" value="network-xhr2"> network-xhr2</label></li>
+                          <li id="network_xhr2"><label><input type="checkbox" value="network_xhr2"> network-xhr2</label></li>
                           <li id="notification"><label><input type="checkbox" value="notification"> notification</label></li>
                           <li id="performance"><label><input type="checkbox" value="performance"> performance</label></li>
-                          <li id="pointerlock-api"><label><input type="checkbox" value="pointerlock-api"> pointerlock-api</label></li>
+                          <li id="pointerlock_api"><label><input type="checkbox" value="pointerlock_api"> pointerlock-api</label></li>
 
                           <li id="quota_management_api"><label><input type="checkbox" value="quota_management_api"> quota-management-api</label></li>
                           <li id="requestanimationframe"><label><input type="checkbox" value="requestanimationframe"> requestanimationframe</label></li>
                           <li id="script_async"><label><input type="checkbox" value="script_async"> script-async</label></li>
                           <li id="script_defer"><label><input type="checkbox" value="script_defer"> script-defer</label></li>
-                          <li id="style-scoped"><label><input type="checkbox" value="style-scoped"> style-scoped</label></li>
-                          <li id="svg-filters"><label><input type="checkbox" value="svg-filters"> svg-filters</label></li>
+                          <li id="style_scoped"><label><input type="checkbox" value="style_scoped"> style-scoped</label></li>
+                          <li id="svg_filters"><label><input type="checkbox" value="svg_filters"> svg-filters</label></li>
                           <li id="unicode"><label><input type="checkbox" value="unicode"> unicode</label></li>
                           <li id="url_data_uri"><label><input type="checkbox" value="url_data_uri"> url-data-uri</label></li>
 


### PR DESCRIPTION
The Build URL doesn't work for some detects that have dashes in their input values. This includes network-xhr2, blob-constrctor and others. If you generate modernizr with network-xhr2 support, and then try to visit the Build URL included in the modernize file, the network-xhr2 detect is not selected as it should.

The same happens for a few other detects. All of them fixed.
