### PR TITLE
Use modernizr-latest.js as reference for development version

### DIFF
--- a/download/index.html
+++ b/download/index.html
@@ -5,7 +5,7 @@ body_id: builder
 ---
             <section id="download" class="wt ">
                <h2><a href="/download/" class="wt dl-link">Download Modernizr {{ site.latest_version }}</a></h2>
-               <p class="intro-p">Use the <a href="/downloads/modernizr.js">Development version</a> to develop with and learn from. Then, when you’re ready for production, use the build tool below to pick only the tests you need.</p>
+               <p class="intro-p">Use the <a href="/downloads/modernizr-latest.js">Development version</a> to develop with and learn from. Then, when you’re ready for production, use the build tool below to pick only the tests you need.</p>
 
                <div class="swap-region">
                <form action="#" class="builder">


### PR DESCRIPTION
As suggested in gh-25: modernizr-latest.js seems to be maintained, modernizr.js isn't.
