### PR TITLE
Removes duplicate jQuery request

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -26,7 +26,6 @@
    </script>
 
 
-   <script src="/i/js/jquery-1.7.min.js"></script>
    <script src="/i/js/modernizr.com-custom-2.6.1-01.js"></script>
    <script src="/i/js/respond.min.js"></script>
 </head>


### PR DESCRIPTION
jQuery is loaded twice. Firstly in the `_layouts/default.html` file and then secondly through the modernizer.load in `i/js/modernizr.com-custom-2.6.1-01.js`

1.7 is loaded via yepnope and 1.7.2 is loaded via the default layout.

Should be as simple as removing the jQuery loaded in default.html?
